### PR TITLE
Fix version input

### DIFF
--- a/cves/2016/8xxx/CVE-2016-8610.json
+++ b/cves/2016/8xxx/CVE-2016-8610.json
@@ -16,7 +16,9 @@
                         },
                         {
                             "status": "affected",
-                            "version": "1.0.2 through 1.0.2h"
+                            "version": "1.0.2",
+                            "lessThanOrEqual": "1.0.2h",
+                            "versionType": "custom"
                         },
                         {
                             "status": "affected",

--- a/cves/2017/0xxx/CVE-2017-0379.json
+++ b/cves/2017/0xxx/CVE-2017-0379.json
@@ -8,7 +8,9 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "libgcrypt"
+                            "version": "*",
+                            "lessThan": "1.8.1",
+                            "versionType": "semver"
                         }
                     ]
                 }

--- a/cves/2018/0xxx/CVE-2018-0732.json
+++ b/cves/2018/0xxx/CVE-2018-0732.json
@@ -8,11 +8,15 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.1.0i-dev (Affected 1.1.0-1.1.0h)"
+                            "version": "1.1.0",
+                            "lessThan": "1.1.0i-dev",
+                            "versionType": "custom"
                         },
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.0.2p-dev (Affected 1.0.2-1.0.2o)"
+                            "version": "1.0.2",
+                            "lessThan": "1.0.2p-dev",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2018/0xxx/CVE-2018-0733.json
+++ b/cves/2018/0xxx/CVE-2018-0733.json
@@ -8,7 +8,9 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.1.0h (Affected 1.1.0-1.1.0g)"
+                            "version": "1.1.0",
+                            "lessThan": "1.1.0h",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2018/0xxx/CVE-2018-0734.json
+++ b/cves/2018/0xxx/CVE-2018-0734.json
@@ -8,15 +8,21 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.1.1a (Affected 1.1.1)"
+                            "version": "1.1.1",
+                            "lessThan": "1.1.1a",
+                            "versionType": "custom"
                         },
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.1.0j (Affected 1.1.0-1.1.0i)"
+                            "version": "1.1.0",
+                            "lessThan": "1.1.0j",
+                            "versionType": "custom"
                         },
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.0.2q (Affected 1.0.2-1.0.2p)"
+                            "version": "1.0.2",
+                            "lessThan": "1.0.2q",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2018/0xxx/CVE-2018-0735.json
+++ b/cves/2018/0xxx/CVE-2018-0735.json
@@ -8,11 +8,15 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.1.0j (Affected 1.1.0-1.1.0i)"
+                            "version": "1.1.0",
+                            "lessThan": "1.1.0j",
+                            "versionType": "custom"
                         },
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.1.1a (Affected 1.1.1)"
+                            "version": "1.1.1",
+                            "lessThan": "1.1.1a",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2018/0xxx/CVE-2018-0737.json
+++ b/cves/2018/0xxx/CVE-2018-0737.json
@@ -8,11 +8,15 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.1.0i-dev (Affected 1.1.0-1.1.0h)"
+                            "version": "1.1.0",
+                            "lessThan": "1.1.0i-dev",
+                            "versionType": "custom"
                         },
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.0.2p-dev (Affected 1.0.2b-1.0.2o)"
+                            "version": "1.0.2b",
+                            "lessThan": "1.0.2p-dev",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2018/0xxx/CVE-2018-0739.json
+++ b/cves/2018/0xxx/CVE-2018-0739.json
@@ -3,16 +3,21 @@
         "cna": {
             "affected": [
                 {
+                    "defaultStatus": "unaffected",
                     "product": "OpenSSL",
                     "vendor": "OpenSSL",
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.1.0h (Affected 1.1.0-1.1.0g)"
+                            "version": "1.1.0",
+                            "lessThanOrEqual": "1.1.0g",
+                            "versionType": "custom"
                         },
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.0.2o (Affected 1.0.2b-1.0.2n)"
+                            "version": "1.0.2b",
+                            "lessThanOrEqual": "1.0.2n",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2018/14xxx/CVE-2018-14647.json
+++ b/cves/2018/14xxx/CVE-2018-14647.json
@@ -8,7 +8,27 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "3.8, 3.7, 3.6, 3.5, 3.4, 2.7"
+                            "version": "3.8"
+                        },
+                        {
+                            "status": "affected",
+                            "version": "3.7"
+                        },
+                        {
+                            "status": "affected",
+                            "version": "3.6"
+                        },
+                        {
+                            "status": "affected",
+                            "version": "3.5"
+                        },
+                        {
+                            "status": "affected",
+                            "version": "3.4"
+                        },
+                        {
+                            "status": "affected",
+                            "version": "2.7"
                         }
                     ]
                 }

--- a/cves/2019/1xxx/CVE-2019-1552.json
+++ b/cves/2019/1xxx/CVE-2019-1552.json
@@ -31,16 +31,22 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c)",
-                            "status": "affected"
+                            "version": "1.1.1",
+                            "status": "affected",
+                            "lessThan": "1.1.1d",
+                            "versionType": "custom"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.1.0l (Affected 1.1.0-1.1.0k)",
-                            "status": "affected"
+                            "version": "1.1.0",
+                            "status": "affected",
+                            "lessThan": "1.1.0l",
+                            "versionType": "custom"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.0.2t (Affected 1.0.2-1.0.2s)",
-                            "status": "affected"
+                            "version": "1.0.2",
+                            "status": "affected",
+                            "lessThan": "1.0.2t",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2019/5xxx/CVE-2019-5018.json
+++ b/cves/2019/5xxx/CVE-2019-5018.json
@@ -8,7 +8,11 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "SQLite 3.26.0, 3.27.0"
+                            "version": "3.26.0"
+                        },
+                        {
+                            "status": "affected",
+                            "version": "3.27.0"
                         }
                     ]
                 }

--- a/cves/2019/5xxx/CVE-2019-5094.json
+++ b/cves/2019/5xxx/CVE-2019-5094.json
@@ -8,7 +8,9 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "E2fsprogs 1.43.3 - 1.45.3"
+                            "version": "1.43.3",
+                            "lessThanOrEqual": "1.45.3",
+                            "versionType": "semver"
                         }
                     ]
                 }

--- a/cves/2019/5xxx/CVE-2019-5188.json
+++ b/cves/2019/5xxx/CVE-2019-5188.json
@@ -8,7 +8,9 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "1.43.3 - 1.45.4"
+                            "version": "1.43.3",
+                            "lessThanOrEqual": "1.45.4",
+                            "versionType": "semver"
                         }
                     ]
                 }

--- a/cves/2019/8xxx/CVE-2019-8457.json
+++ b/cves/2019/8xxx/CVE-2019-8457.json
@@ -7,8 +7,10 @@
                     "vendor": "n/a",
                     "versions": [
                         {
+                            "version": "3.6.0",
                             "status": "affected",
-                            "version": "From 3.6.0 to 3.27.2 including"
+                            "lessThanOrEqual": "3.27.2",
+                            "versionType": "semver"
                         }
                     ]
                 }

--- a/cves/2020/1xxx/CVE-2020-1967.json
+++ b/cves/2020/1xxx/CVE-2020-1967.json
@@ -8,7 +8,9 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f)"
+                            "version": "1.1.1d",
+                            "lessThan": "1.1.1g",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2020/1xxx/CVE-2020-1968.json
+++ b/cves/2020/1xxx/CVE-2020-1968.json
@@ -31,8 +31,10 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 1.0.2w (Affected 1.0.2-1.0.2v)",
-                            "status": "affected"
+                            "version": "1.0.2",
+                            "status": "affected",
+                            "lessThan": "1.0.2w",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2020/1xxx/CVE-2020-1971.json
+++ b/cves/2020/1xxx/CVE-2020-1971.json
@@ -8,11 +8,15 @@
                     "versions": [
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h)"
+                            "version": "1.1.1",
+                            "lessThan": "1.1.1i",
+                            "versionType": "custom"
                         },
                         {
                             "status": "affected",
-                            "version": "Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w)"
+                            "version": "1.0.2",
+                            "lessThan": "1.0.2x",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2021/3xxx/CVE-2021-3426.json
+++ b/cves/2021/3xxx/CVE-2021-3426.json
@@ -29,7 +29,15 @@
                     "product": "python",
                     "versions": [
                         {
-                            "version": "python 3.8.9, python 3.9.3, python 3.10.0a7",
+                            "version": "3.8.9",
+                            "status": "affected"
+                        },
+                        {
+                            "version": "3.9.3",
+                            "status": "affected"
+                        },
+                        {
+                            "version": "3.10.0a7",
                             "status": "affected"
                         }
                     ]

--- a/cves/2021/3xxx/CVE-2021-3711.json
+++ b/cves/2021/3xxx/CVE-2021-3711.json
@@ -31,8 +31,10 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k)",
-                            "status": "affected"
+                            "version": "1.1.1",
+                            "status": "affected",
+                            "lessThan": "1.1.1l",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2021/3xxx/CVE-2021-3712.json
+++ b/cves/2021/3xxx/CVE-2021-3712.json
@@ -31,12 +31,16 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k)",
-                            "status": "affected"
+                            "version": "1.1.1",
+                            "status": "affected",
+                            "lessThan": "1.1.1l",
+                            "versionType": "custom"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y)",
-                            "status": "affected"
+                            "version": "1.0.2",
+                            "status": "affected",
+                            "lessThan": "1.0.2za",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2021/4xxx/CVE-2021-4160.json
+++ b/cves/2021/4xxx/CVE-2021-4160.json
@@ -31,16 +31,22 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 3.0.1 (Affected 3.0.0)",
-                            "status": "affected"
+                            "version": "3.0.0",
+                            "status": "affected",
+                            "lessThan": "3.0.1",
+                            "versionType": "semver"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.1.1m (Affected 1.1.1-1.1.1l)",
-                            "status": "affected"
+                            "version": "1.1.1",
+                            "status": "affected",
+                            "lessThan": "1.1.1m",
+                            "versionType": "custom"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.0.2zc-dev (Affected 1.0.2-1.0.2zb)",
-                            "status": "affected"
+                            "version": "1.0.2",
+                            "status": "affected",
+                            "lessThan": "1.0.2zc-dev",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2022/0xxx/CVE-2022-0391.json
+++ b/cves/2022/0xxx/CVE-2022-0391.json
@@ -29,7 +29,23 @@
                     "product": "python",
                     "versions": [
                         {
-                            "version": "python 3.10.0b1, python 3.9.5, python 3.8.11, python 3.7.11, python 3.6.14",
+                            "version": "3.10.0b1",
+                            "status": "affected"
+                        },
+                        {
+                            "version": "3.9.5",
+                            "status": "affected"
+                        },
+                        {
+                            "version": "3.8.11",
+                            "status": "affected"
+                        },
+                        {
+                            "version": "3.7.11",
+                            "status": "affected"
+                        },
+                        {
+                            "version": "3.6.14",
                             "status": "affected"
                         }
                     ]

--- a/cves/2022/0xxx/CVE-2022-0778.json
+++ b/cves/2022/0xxx/CVE-2022-0778.json
@@ -31,16 +31,22 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 3.0.2 (Affected 3.0.0,3.0.1)",
-                            "status": "affected"
+                            "version": "3.0.0",
+                            "status": "affected",
+                            "lessThan": "3.0.2",
+                            "versionType": "semver"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.1.1n (Affected 1.1.1-1.1.1m)",
-                            "status": "affected"
+                            "version": "1.1.1",
+                            "status": "affected",
+                            "lessThan": "1.1.1n",
+                            "versionType": "custom"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.0.2zd (Affected 1.0.2-1.0.2zc)",
-                            "status": "affected"
+                            "version": "1.0.2",
+                            "status": "affected",
+                            "lessThan": "1.0.2zd",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2022/1xxx/CVE-2022-1292.json
+++ b/cves/2022/1xxx/CVE-2022-1292.json
@@ -31,16 +31,22 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 3.0.3 (Affected 3.0.0,3.0.1,3.0.2)",
-                            "status": "affected"
+                            "version": "3.0.0",
+                            "status": "affected",
+                            "lessThan": "3.0.3",
+                            "versionType": "semver"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.1.1o (Affected 1.1.1-1.1.1n)",
-                            "status": "affected"
+                            "version": "1.1.1",
+                            "status": "affected",
+                            "lessThan": "1.1.1o",
+                            "versionType": "custom"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.0.2ze (Affected 1.0.2-1.0.2zd)",
-                            "status": "affected"
+                            "version": "1.0.2",
+                            "status": "affected",
+                            "lessThan": "1.0.2ze",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2022/1xxx/CVE-2022-1343.json
+++ b/cves/2022/1xxx/CVE-2022-1343.json
@@ -31,8 +31,10 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 3.0.3 (Affected 3.0.0,3.0.1,3.0.2)",
-                            "status": "affected"
+                            "version": "3.0.0",
+                            "status": "affected",
+                            "lessThan": "3.0.3",
+                            "versionType": "semver"
                         }
                     ]
                 }

--- a/cves/2022/1xxx/CVE-2022-1434.json
+++ b/cves/2022/1xxx/CVE-2022-1434.json
@@ -31,8 +31,10 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 3.0.3 (Affected 3.0.0,3.0.1,3.0.2)",
-                            "status": "affected"
+                            "version": "3.0.0",
+                            "status": "affected",
+                            "lessThan": "3.0.3",
+                            "versionType": "semver"
                         }
                     ]
                 }

--- a/cves/2022/1xxx/CVE-2022-1473.json
+++ b/cves/2022/1xxx/CVE-2022-1473.json
@@ -31,8 +31,10 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 3.0.3 (Affected 3.0.0,3.0.1,3.0.2)",
-                            "status": "affected"
+                            "version": "3.0.0",
+                            "status": "affected",
+                            "lessThan": "3.0.3",
+                            "versionType": "semver"
                         }
                     ]
                 }

--- a/cves/2022/2xxx/CVE-2022-2068.json
+++ b/cves/2022/2xxx/CVE-2022-2068.json
@@ -31,16 +31,22 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 3.0.4 (Affected 3.0.0,3.0.1,3.0.2,3.0.3)",
-                            "status": "affected"
+                            "version": "3.0.0",
+                            "status": "affected",
+                            "lessThan": "3.0.4",
+                            "versionType": "semver"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.1.1p (Affected 1.1.1-1.1.1o)",
-                            "status": "affected"
+                            "version": "1.1.1",
+                            "status": "affected",
+                            "lessThan": "1.1.1p",
+                            "versionType": "custom"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.0.2zf (Affected 1.0.2-1.0.2ze)",
-                            "status": "affected"
+                            "version": "1.0.2",
+                            "status": "affected",
+                            "lessThan": "1.0.2zf",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2022/2xxx/CVE-2022-2097.json
+++ b/cves/2022/2xxx/CVE-2022-2097.json
@@ -31,12 +31,16 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 3.0.5 (Affected 3.0.0-3.0.4)",
-                            "status": "affected"
+                            "version": "3.0.0",
+                            "status": "affected",
+                            "lessThan": "3.0.5",
+                            "versionType": "semver"
                         },
                         {
-                            "version": "Fixed in OpenSSL 1.1.1q (Affected 1.1.1-1.1.1p)",
-                            "status": "affected"
+                            "version": "1.1.1",
+                            "status": "affected",
+                            "lessThan": "1.1.1q",
+                            "versionType": "custom"
                         }
                     ]
                 }

--- a/cves/2022/3xxx/CVE-2022-3358.json
+++ b/cves/2022/3xxx/CVE-2022-3358.json
@@ -31,8 +31,10 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 3.0.6 (Affected 3.0.0-3.0.5)",
-                            "status": "affected"
+                            "version": "3.0.0",
+                            "status": "affected",
+                            "lessThan": "3.0.6",
+                            "versionType": "semver"
                         }
                     ]
                 }

--- a/cves/2022/3xxx/CVE-2022-3602.json
+++ b/cves/2022/3xxx/CVE-2022-3602.json
@@ -31,8 +31,10 @@
                     "product": "OpenSSL",
                     "versions": [
                         {
-                            "version": "Fixed in OpenSSL 3.0.7 (Affected 3.0.0,3.0.1,3.0.2,3.0.3,3.0.4,3.0.5,3.0.6)",
-                            "status": "affected"
+                            "version": "3.0.0",
+                            "status": "affected",
+                            "lessThan": "3.0.7",
+                            "versionType": "semver"
                         }
                     ]
                 }


### PR DESCRIPTION
Fix version input of the following CVEs:

- 2016 : CVE-2016-8610
- 2017 : CVE-2017-0379
- 2018 : CVE-2018-0732, CVE-2018-0733, CVE-2018-0737, CVE-2018-0739, CVE-2018-14647
- 2019 : CVE-2019-1552, CVE-2019-5018, CVE-2019-5094, CVE-2019-5188, CVE-2019-8457
- 2020 : CVE-2020-1967, CVE-2020-1968, CVE-2020-1971
- 2021 : CVE-2021-3426, CVE-2021-3711, CVE-2021-3712, CVE-2021-4160
- 2022 : CVE-2022-0391, CVE-2022-0778, CVE-2022-1292, CVE-2022-1343, CVE-2022-1434, CVE-2022-1473, CVE-2022-2068, CVE-2022-2097, CVE-2022-3358, CVE-2022-3602